### PR TITLE
remove Eventable since it is now part of Vienna::Model

### DIFF
--- a/opal/vienna/ajax.rb
+++ b/opal/vienna/ajax.rb
@@ -86,8 +86,6 @@ module Vienna
       base.extend ClassMethods
       # find method from Enumerable conflicts with Vienna::Model
       #base.extend Enumerable
-      base.include Vienna::Eventable
-      base.extend Vienna::Eventable
     end
   end
 end


### PR DESCRIPTION
This PR removes `Vienna::Eventable` from `Vienna::Ajax` storage mixin, as `Vienna::Eventable` is now included in `Vienna::Model` by default.
