### PR TITLE
Fix the creation of child view element.

### DIFF
--- a/opal/vienna/view.rb
+++ b/opal/vienna/view.rb
@@ -34,12 +34,12 @@ module Vienna
     end
 
     def create_element
-      scope = (self.parent ? parent.element : Element)
-
       if el = self.class.element
+        scope = (self.parent ? parent.element : Element)
         scope.find el
       else
-        e = scope.new tag_name
+        e = Element.new tag_name
+        e.append_to parent.element if parent
         e.add_class class_name
       end
     end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -73,6 +73,14 @@ describe Vienna::View do
         child.parent = parent
         child.create_element.size.should eq(0)
       end
+
+      it "creates a child element of parent element when no element defined" do
+        parent = Class.new(Vienna::View) { element "#parent-element" }.new
+        child  = Class.new(Vienna::View).new
+        
+        child.parent = parent
+        child.create_element.parent.id.should eq("parent-element")
+      end
     end
   end
 end


### PR DESCRIPTION
Without this fix, creating the element of a child view fails with an error:

```
     NoMethodError:
       undefined method `new' for #<Element [<div>]>
```

Another way to fix this would be to define `Element#new` in opal-jquery, but I don't think that has a direct analog in jQuery so maybe it doesn't belong there?
